### PR TITLE
Specify solver & mediator

### DIFF
--- a/lilypad/lilypad-aurora-reference/run-a-node.md
+++ b/lilypad/lilypad-aurora-reference/run-a-node.md
@@ -88,6 +88,8 @@ Environment="LOG_TYPE=json"
 Environment="LOG_LEVEL=debug"
 Environment="HOME=/app/lilypad"
 Environment="OFFER_GPU=1"
+Environment="SERVICE_SOLVER=0xd4646ef9f7336b06841db3019b617ceadf435316"
+Environment="SERVICE_MEDIATORS=0x2d83ced7562e406151bd49c749654429907543b4"
 EnvironmentFile=/app/lilypad/resource-provider-gpu.env
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
Fixes the issue of `No solver service specified - please use SERVICE_SOLVER or --service-solver`

Values for solver and mediator are as obtained at https://docs.lilypad.tech/lilypad/lilypad-aurora-testnet/quick-start/install-run-requirements