### PR TITLE
docs: Add Bacalhau supported versions note

### DIFF
--- a/lilypad/hardware-providers/run-a-node.md
+++ b/lilypad/hardware-providers/run-a-node.md
@@ -106,9 +106,9 @@ To install Bacalhau, run the following in your terminal:
 ```bash
 cd /tmp
 
-wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.3.0/bacalhau_v1.3.0_linux_amd64.tar.gz
+wget https://github.com/bacalhau-project/bacalhau/releases/download/v1.3.2/bacalhau_v1.3.2_linux_amd64.tar.gz
 
-tar xfv bacalhau_v1.3.0_linux_amd64.tar.gz
+tar xfv bacalhau_v1.3.2_linux_amd64.tar.gz
 
 sudo mv bacalhau /usr/bin/bacalhau
 
@@ -116,6 +116,8 @@ sudo mkdir -p /app/data/ipfs
 
 sudo chown -R $USER /app/data
 ```
+
+Bacalhau versions newer than `v1.3.2` are not currently supported but will be in the future. Please pin to Bacalhau `v.1.3.2` for now.
 
 #### Install Lilypad
 


### PR DESCRIPTION
This pull request implements the following changes:

- [x] Update Bacalhau install script to use `v1.3.2`
- [x] Add note to pin Bacalhau at `v1.3.2`

Bacalhau removed support for embedded IPFS nodes: https://github.com/bacalhau-project/bacalhau/issues/3816. The last version to support embedded IPFS nodes is `v1.3.2`.

We will eventually support newer versions of Bacalhau, but for now we should ask resource providers to use `v.1.3.2`.
