### PR TITLE
Added info about tokens to FAQ and a link to them from the funding yo…

### DIFF
--- a/lilypad/faqs.md
+++ b/lilypad/faqs.md
@@ -57,7 +57,18 @@ Phases 2 and onward will provide rewards for Lilypad modules created as well as 
 
 ### How do I check my Lilybit\_ rewards?
 
-You can check your rewards by pasting your nodes wallet address into the following interfaces:
+You can check your rewards by pasting your nodes wallet address into the following inteerfaces:
+
+### How does Lilypad use blockchain, and why do I need both ETH and Lilypad tokens to run a job?
+
+On the Lilypad network, The blockchain is used for
+* payment rails
+* storing the deals transparently (on-chain guarantees about the compute)
+* storing any disputes & results
+
+Lilypad Tokens  are used to transact on the Lilypad network. They are used as payment by those who want to run jobs (to the resource providers who run them), and as collateral by resource providers
+
+You need ETH tokens to pay for the gas fees for smart contracts the facilitate transactions, and for records of transactions and disputes that are posted to the Ethereum blockchain.
 
 * [Grafana dashboard](https://grafana.lilypad.tech/d/adxhou3o1q8sga/rewards-per-wallets?orgId=1\&refresh=1m)
 * [Lilypad leaderboard](https://info.lilypad.tech/leaderboard)

--- a/lilypad/lilypad-testnet/quick-start/funding-your-wallet-from-faucet.md
+++ b/lilypad/lilypad-testnet/quick-start/funding-your-wallet-from-faucet.md
@@ -12,7 +12,7 @@ description: Get Testnet Lilypad Tokens (LP) and Arbitrum Sepolia Testnet ETH
 ## Faucet Guide
 
 ### Get Testnet LP tokens
-Find out what you need tokens in the [FAQs](../..faqs.md)
+Find out why you need tokens in the [FAQs](../..faqs.md)
 
 Navigate to the Lilypad Testnet [faucet](https://faucet-testnet.lilypad.tech/). Copy your MetaMask wallet address into the input and click "Request".
 

--- a/lilypad/lilypad-testnet/quick-start/funding-your-wallet-from-faucet.md
+++ b/lilypad/lilypad-testnet/quick-start/funding-your-wallet-from-faucet.md
@@ -12,6 +12,7 @@ description: Get Testnet Lilypad Tokens (LP) and Arbitrum Sepolia Testnet ETH
 ## Faucet Guide
 
 ### Get Testnet LP tokens
+Find out what you need tokens in the [FAQs](../..faqs.md)
 
 Navigate to the Lilypad Testnet [faucet](https://faucet-testnet.lilypad.tech/). Copy your MetaMask wallet address into the input and click "Request".
 


### PR DESCRIPTION
…page, unable to serve locally and test

### Summary

This pull request makes the following changes:

- [ ] Adds to FAQ ### How does Lilypad use blockchain, and why do I need both ETH and Lilypad tokens to run a job?
- [ ] Puts a link to FAQ in lilypad/lilypad-testnet/quick-start/funding-your-wallet-from-faucet.md

Explain the motivation for making these changes.
It's unclear to users why we are funding a wallet with two tokens, esp if user isn't web3 native

### Task/Issue reference

Closes: add_link_here

### Test plan

Tried to serve locally with Gitbook, but I cannot, for some reason it's installing the wrong gitbook version. If you have any advice on how to setup and serve locally let me know

### Details (optional)
It's up to you if you think this is relevant to include! It's a suggestion. Another option would be to add a brief explanation in the 

### Related issues or PRs (optional)

Add any related issues or PRs.
