### PR TITLE
create `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+################################################################
+#
+# List of approvers/reviewers for Lilypad Network Documentation
+#
+################################################################
+#
+# Get in touch with us via the Lilypad Community Discord
+#  https://discord.gg/WtHbjMP5UB
+# 
+#
+# Learn about CODEOWNERS file format: 
+#  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+
+# The default owners for everything in the repo.
+* @DevlinRocha @PBillingsby @galaxyxtwo
+
+# The default owners for any file in a `/quick-start` directory.
+**/quick-start @DevlinRocha @PBillingsby @galaxyxtwo @noryev
+
+# The default owners for any file in the `/lilypad/lilypad-testnet` directory.
+/lilypad/lilypad-testnet @DevlinRocha @PBillingsby @galaxyxtwo @noryev


### PR DESCRIPTION
### Summary

- adds a `CODEOWNERS` file
    - by default, any changes made in the `lilypad-docs` repo will automatically request a review from @DevlinRocha, @PBillingsby, and @galaxyxtwo
    - by default, any changes made in a `/quick-start` directory will automatically request a review from @DevlinRocha, @PBillingsby, @galaxyxtwo, and @noryev
    - by default, any changes made in the the `/lilypad/lilypad-testnet` directory will automatically request a review from @DevlinRocha, @PBillingsby, @galaxyxtwo, and @noryev


#### Idea (optional)

we can create a new @Lilypad-Tech [team](https://github.com/orgs/Lilypad-Tech/teams) for DevRel, and instead of tagging individual code owners, we can use `@Lilypad-Tech/DevRel`