### PR TITLE
Added node version required to run lilypad-llama3-chatbot

### DIFF
--- a/lilypad/tooling-plugins-and-integrations/ai-tooling/lilypad-llama3-chatbot.md
+++ b/lilypad/tooling-plugins-and-integrations/ai-tooling/lilypad-llama3-chatbot.md
@@ -26,6 +26,10 @@ This chatbot can be extended with:
 3. **Response Generation** – Llama3 processes the input, considers context and generates a natural language response.
 4. **Response Display** – The response is rendered in the chatbot interface.
 
+### **Prerequisites:**
+
+* **[Node.js](https://nodejs.org/en)** – 18 LTS or newer
+
 ### **Installation**
 
 1. Get [Anura API key](https://anura.lilypad.tech/).


### PR DESCRIPTION
### Summary

This pull request makes the following changes:

- Added node version required to run lilypad-llama3-chatbot

Explain the motivation for making these changes. Does this pull request implement a feature or fix a bug? Is it a docs change or a typo fix?

I updated the docs because a user ran into an issue with their node version. I noted the node version we need to run the llama chatbot. https://discord.com/channels/1212897693450641498/1344357862482251889/1383165442306343023